### PR TITLE
Support default location of jni.h, based on Xcode.app default platform.

### DIFF
--- a/hello/hello.xcodeproj/project.pbxproj
+++ b/hello/hello.xcodeproj/project.pbxproj
@@ -427,7 +427,10 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
-				HEADER_SEARCH_PATHS = /System/Library/Frameworks/JavaVM.framework/Headers;
+				HEADER_SEARCH_PATHS = (
+					/System/Library/Frameworks/JavaVM.framework/Headers,
+					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers,
+				);
 				INFOPLIST_FILE = hello/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -448,7 +451,10 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
-				HEADER_SEARCH_PATHS = /System/Library/Frameworks/JavaVM.framework/Headers;
+				HEADER_SEARCH_PATHS = (
+					/System/Library/Frameworks/JavaVM.framework/Headers,
+					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers,
+				);
 				INFOPLIST_FILE = hello/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/makefile
+++ b/makefile
@@ -71,6 +71,7 @@ flags = -isysroot $(sdk-dir)/$(target)$(ios-version).sdk \
 cflags = $(flags) -D__IPHONE_OS_VERSION_MIN_REQUIRED=80000 -DRESOURCES \
 	-fobjc-abi-version=2 -fobjc-legacy-dispatch \
 	-I/System/Library/Frameworks/JavaVM.framework/Headers \
+    -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers \
 	-mios-version-min=$(ios-version)
 
 ifeq ($(mode),debug)


### PR DESCRIPTION
Current build OSX environment does not provide anymore header files in the proposed location (probably because of Oracle instead of Apple based JDK).

This is a proposal to include both locations - I know that this might not be the optimal solution, but it is something that doesn't break a default development environment.